### PR TITLE
Add Android project skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # Ordenamelas-anda
-App android para crear rutas de reparto. Para mi amiga Vane
+
+Esqueleto de aplicación Android para optimizar rutas de reparto por voz.
+
+## Módulos
+- `app/` interfaz de usuario y lógica Android.
+- `core/` modelos y utilidades de generación de rutas.
+- `api/` clientes para servicios externos (Google Maps, OpenAI).
+
+Incluye script `setup.sh` para preparar el entorno Android (pendiente de implementar).

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,0 +1,7 @@
+apply plugin: 'java-library'
+apply plugin: 'kotlin'
+
+dependencies {
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.8.21'
+    // TODO: add OpenAI and Google Maps dependencies
+}

--- a/api/src/main/java/com/example/routes/RouteOptimizer.kt
+++ b/api/src/main/java/com/example/routes/RouteOptimizer.kt
@@ -1,0 +1,7 @@
+package com.example.routes
+
+class RouteOptimizer {
+    fun optimize(currentLat: Double, currentLng: Double, addresses: List<String>) {
+        // TODO: implement call to Google Maps Route Optimization API
+    }
+}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,0 +1,31 @@
+apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion 33
+
+    defaultConfig {
+        applicationId "com.example.routes"
+        minSdkVersion 24
+        targetSdkVersion 33
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation project(':core')
+    implementation project(':api')
+
+    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.9.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1'
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.routes">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+
+    <application
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:icon="@mipmap/ic_launcher">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/app/src/main/java/com/example/routes/MainActivity.kt
+++ b/app/src/main/java/com/example/routes/MainActivity.kt
@@ -1,0 +1,29 @@
+package com.example.routes
+
+import android.Manifest
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+
+class MainActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        // TODO: setup UI and buttons
+    }
+
+    fun startListening() {
+        // TODO: start SpeechRecognizer
+    }
+
+    fun stopListening() {
+        // TODO: stop SpeechRecognizer
+    }
+
+    fun onResults(results: List<String>) {
+        // TODO: handle speech results
+    }
+
+    fun optimizeRoute() {
+        // TODO: call optimization API and generate GPX/KML
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Ordenamelas</string>
+</resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,16 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:7.4.2'
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,0 +1,6 @@
+apply plugin: 'java-library'
+apply plugin: 'kotlin'
+
+dependencies {
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.8.21'
+}

--- a/core/src/main/java/com/example/routes/Address.kt
+++ b/core/src/main/java/com/example/routes/Address.kt
@@ -1,0 +1,8 @@
+package com.example.routes
+
+// TODO: define address fields
+data class Address(
+    val postalCode: String,
+    val street: String,
+    val number: String
+)

--- a/core/src/main/java/com/example/routes/Route.kt
+++ b/core/src/main/java/com/example/routes/Route.kt
@@ -1,0 +1,8 @@
+package com.example.routes
+
+// TODO: define route fields
+class Route(
+    val addresses: List<Address>
+) {
+    // TODO: add functions to convert to GPX/KML
+}

--- a/prompts/initial.txt
+++ b/prompts/initial.txt
@@ -1,0 +1,34 @@
+Ayúdame a generar la estructura inicial de una app Android en Java (o Kotlin si lo prefieres) para que mi amiga Vane pueda optimizar sus rutas de reparto de notificaciones de Correos. Debe incluir:
+
+1. Objetivos funcionales:
+   - Un botón “Push to Talk” que lance el reconocimiento de voz y capture direcciones en formato “Código Postal, Calle, Número”.
+   - Una lista dinámica donde se vayan almacenando todas las direcciones dictadas.
+   - Un botón “Terminado” que, al pulsarlo, obtenga la ubicación GPS actual del dispositivo.
+   - Llamada a la Google Maps Route Optimization API (o Fleet Engine Route Optimization) para:
+     • Ordenar las paradas desde la posición actual de Vane.
+     • Calcular una ruta circular eficiente según tráfico y restricciones de callejero.
+   - Generación de un archivo GPX (o KML) con la ruta optimizada.
+   - Posibilidad de lanzar un Intent a Google Maps (u otra app GPS) importando ese GPX/KML para navegación.
+
+2. Estrategias técnicas:
+   - **Modularidad Maven/Gradle**:
+     • `app/`: UI Android, reconocimiento de voz, manejo de lista y navegación.
+     • `core/`: modelos de datos (Dirección, Ruta), lógica de conversión a GPX.
+     • `api/`: cliente OpenAI Codex (para scaffolding) y cliente Google Maps (Route Optimization).
+   - **Dependencias clave**:
+     • AndroidX Material, Lifecycle, ViewModel.
+     • SpeechRecognizer de Android.
+     • Google Maps Platform: “platform-tools”, “platforms;android-33”, “build-tools;33.0.0” instalados.
+     • Librería oficial `com.openai:openai` para invocar Codex desde scripts si se desea.
+   - **Gestión de licencias y entorno**:
+     • Script `setup.sh` que instale JDK 11, Android SDK CLI, acepte licencias headless y deje Maven/Gradle listos.
+     • Variables ANDROID_SDK_ROOT y PATH configuradas en `~/.bashrc`.
+   - **Formato de salida**:
+     • Carpeta `prompts/` con este `initial.txt`.
+     • `build.gradle` y `AndroidManifest.xml` con permisos de INTERNET, RECORD_AUDIO y ACCESS_FINE_LOCATION.
+     • MainActivity.java (o MainActivity.kt) con métodos stub: `startListening()`, `stopListening()`, `onResults()`, `optimizeRoute()`.
+
+3. Resultado esperado:
+   - Un proyecto esquelético con directorios y ficheros básicos.
+   - Dependencias incluidas en `pom.xml` o `build.gradle`.
+   - Clases y manifiesto definidos, con comentarios “// TODO” en los puntos donde implementar la lógica.

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'Ordenamelas-anda'
+include 'app', 'core', 'api'

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Script to install JDK 11 and Android SDK command line tools
+# TODO: implement installation steps and accept licenses


### PR DESCRIPTION
## Summary
- initialize Gradle multi-module project for Android
- add `app`, `core` and `api` modules
- include `MainActivity` stub with voice and route methods
- configure permissions in `AndroidManifest.xml`
- provide `setup.sh` script placeholder
- add prompt file with initial request

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d47709f8c832cae15baef55761f01