### PR TITLE
Add method to launch GPX navigation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,15 @@
         android:allowBackup="true"
         android:label="@string/app_name"
         android:icon="@mipmap/ic_launcher">
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
         <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/example/routes/MainActivity.kt
+++ b/app/src/main/java/com/example/routes/MainActivity.kt
@@ -1,12 +1,18 @@
 package com.example.routes
 
 import android.Manifest
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.widget.Toast
+import androidx.core.content.FileProvider
+import com.example.routes.BuildConfig
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.correos.delivery.core.SpeechRecognitionService
+import com.correos.delivery.export.GpxExporter
+import com.correos.delivery.repository.AddressRepository
 import com.example.routes.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity(), SpeechRecognitionService.Callback {
@@ -52,6 +58,56 @@ class MainActivity : AppCompatActivity(), SpeechRecognitionService.Callback {
     }
 
     fun optimizeRoute() {
-        Toast.makeText(this, "Optimize route not implemented", Toast.LENGTH_SHORT).show()
+        if (addresses.isEmpty()) {
+            Toast.makeText(this, "No addresses to optimize", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        val repo = AddressRepository()
+        for (a in addresses) {
+            val parts = a.split(",").map { it.trim() }
+            repo.add(
+                Address(
+                    postalCode = parts.getOrNull(0) ?: "",
+                    street = parts.getOrNull(1) ?: "",
+                    number = parts.getOrNull(2) ?: "",
+                    latitude = 0.0,
+                    longitude = 0.0
+                )
+            )
+        }
+
+        val exporter = GpxExporter()
+        val gpxFile = try {
+            exporter.export(repo.getAll())
+        } catch (e: Exception) {
+            null
+        }
+
+        if (gpxFile != null) {
+            val uri = FileProvider.getUriForFile(
+                this,
+                "${BuildConfig.APPLICATION_ID}.fileprovider",
+                gpxFile
+            )
+            launchNavigation(uri)
+        } else {
+            Toast.makeText(this, "Failed to export route", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    /**
+     * Open the provided GPX file in an external navigation app such as Google Maps.
+     */
+    fun launchNavigation(gpxUri: Uri) {
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(gpxUri, "application/gpx+xml")
+            flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
+        }
+        if (intent.resolveActivity(packageManager) != null) {
+            startActivity(intent)
+        } else {
+            Toast.makeText(this, "No app found to open GPX", Toast.LENGTH_SHORT).show()
+        }
     }
 }

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="cache" path="." />
+</paths>
+


### PR DESCRIPTION
## Summary
- add FileProvider setup so GPX files can be shared
- export collected addresses as GPX and open them in a navigation app
- create `launchNavigation(Uri)` helper to view GPX files

## Testing
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684d4e64a030832c83526dac6a7959c2