### PR TITLE
Add repository and API tests

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -6,4 +6,6 @@ dependencies {
     // HTTP client for calling Google Maps APIs
     implementation 'com.squareup.okhttp3:okhttp:4.11.0'
     // TODO: add OpenAI and Google Maps dependencies
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-core:5.5.0'
 }

--- a/api/src/main/java/com/correos/delivery/api/RouteOptimizer.java
+++ b/api/src/main/java/com/correos/delivery/api/RouteOptimizer.java
@@ -24,7 +24,15 @@ public class RouteOptimizer {
     private static final String API_KEY = "YOUR_GOOGLE_MAPS_KEY";
     private static final String ENDPOINT = "https://routes.googleapis.com/directions/v2:computeRoutes";
 
-    private final OkHttpClient client = new OkHttpClient();
+    private final OkHttpClient client;
+
+    public RouteOptimizer() {
+        this(new OkHttpClient());
+    }
+
+    public RouteOptimizer(OkHttpClient client) {
+        this.client = client;
+    }
 
     /**
      * Optimize the order of the provided stops by invoking the Google Maps

--- a/api/src/test/java/com/correos/delivery/api/RouteOptimizerTest.kt
+++ b/api/src/test/java/com/correos/delivery/api/RouteOptimizerTest.kt
@@ -1,0 +1,52 @@
+import com.correos.delivery.api.RouteOptimizer
+import com.example.routes.Address
+import okhttp3.*
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.*
+import java.io.IOException
+
+class RouteOptimizerTest {
+    private lateinit var client: OkHttpClient
+    private lateinit var optimizer: RouteOptimizer
+
+    @Before
+    fun setUp() {
+        client = mock(OkHttpClient::class.java)
+        optimizer = RouteOptimizer(client)
+    }
+
+    @Test
+    fun optimizeReturnsStopsOnSuccess() {
+        val stops = listOf(Address("1","A","1",0.0,0.0))
+
+        val call = mock(Call::class.java)
+        val responseBody = ResponseBody.create(MediaType.parse("application/json"), "{}")
+        val response = Response.Builder()
+            .code(200)
+            .protocol(Protocol.HTTP_1_1)
+            .message("OK")
+            .request(Request.Builder().url("https://routes.googleapis.com").build())
+            .body(responseBody)
+            .build()
+
+        `when`(client.newCall(any())).thenReturn(call)
+        `when`(call.execute()).thenReturn(response)
+
+        val result = optimizer.optimize(stops)
+        assertEquals(stops, result)
+    }
+
+    @Test
+    fun optimizeReturnsStopsOnFailure() {
+        val stops = listOf(Address("1","A","1",0.0,0.0))
+
+        val call = mock(Call::class.java)
+        `when`(client.newCall(any())).thenReturn(call)
+        `when`(call.execute()).thenThrow(IOException("boom"))
+
+        val result = optimizer.optimize(stops)
+        assertEquals(stops, result)
+    }
+}

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -3,4 +3,6 @@ apply plugin: 'kotlin'
 
 dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.8.21'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-core:5.5.0'
 }

--- a/core/src/test/java/com/correos/delivery/repository/AddressRepositoryTest.kt
+++ b/core/src/test/java/com/correos/delivery/repository/AddressRepositoryTest.kt
@@ -1,0 +1,31 @@
+import com.correos.delivery.repository.AddressRepository
+import com.example.routes.Address
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+class AddressRepositoryTest {
+    private lateinit var repository: AddressRepository
+
+    @Before
+    fun setUp() {
+        repository = AddressRepository()
+    }
+
+    @Test
+    fun addAndGetAll() {
+        val address = Address("28080", "Street", "1", 1.0, 2.0)
+        repository.add(address)
+        val all = repository.getAll()
+        assertEquals(1, all.size)
+        assertEquals(address, all[0])
+    }
+
+    @Test
+    fun clearRemovesAllAddresses() {
+        repository.add(Address("11111", "A", "1", 0.0, 0.0))
+        repository.add(Address("22222", "B", "2", 0.0, 0.0))
+        repository.clear()
+        assertTrue(repository.getAll().isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit/Mockito test dependencies to `core` and `api` modules
- allow injecting `OkHttpClient` in `RouteOptimizer`
- add unit tests for `AddressRepository`
- add unit tests for `RouteOptimizer` using a mocked `OkHttpClient`

## Testing
- `gradle test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_684d51422fcc832c929bfdec6ca5d1a0