### PR TITLE
Add setup script for Android SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,8 @@ Esqueleto de aplicación Android para optimizar rutas de reparto por voz.
 - `core/` modelos y utilidades de generación de rutas.
 - `api/` clientes para servicios externos (Google Maps, OpenAI).
 
-Incluye script `setup.sh` para preparar el entorno Android (pendiente de implementar).
+Incluye script `setup.sh` para preparar el entorno Android.
+
+## Uso
+Ejecuta `./setup.sh` para instalar JDK 11 y descargar las herramientas de línea de comandos de Android. El script configura la variable `ANDROID_SDK_ROOT` y añade `sdkmanager` al `PATH` en tu `~/.bashrc`. Tras la instalación abre una nueva terminal o ejecuta `source ~/.bashrc` para que los cambios surtan efecto.
+

--- a/setup.sh
+++ b/setup.sh
@@ -1,3 +1,30 @@
 #!/bin/bash
 # Script to install JDK 11 and Android SDK command line tools
-# TODO: implement installation steps and accept licenses
+set -e
+
+sudo apt-get update
+sudo apt-get install -y openjdk-11-jdk wget unzip
+
+# Set up Android SDK directory
+export ANDROID_SDK_ROOT="$HOME/android-sdk"
+mkdir -p "$ANDROID_SDK_ROOT/cmdline-tools"
+
+# Download and extract command line tools
+cd /tmp
+SDK_TOOLS_ZIP=commandlinetools-linux.zip
+wget -q https://dl.google.com/android/repository/commandlinetools-linux-10406996_latest.zip -O "$SDK_TOOLS_ZIP"
+unzip -q "$SDK_TOOLS_ZIP"
+rm "$SDK_TOOLS_ZIP"
+mkdir -p "$ANDROID_SDK_ROOT/cmdline-tools/latest"
+mv cmdline-tools/* "$ANDROID_SDK_ROOT/cmdline-tools/latest/"
+
+# Configure environment variables
+if ! grep -q ANDROID_SDK_ROOT "$HOME/.bashrc"; then
+  echo "export ANDROID_SDK_ROOT=$ANDROID_SDK_ROOT" >> "$HOME/.bashrc"
+  echo "export PATH=\$PATH:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$ANDROID_SDK_ROOT/platform-tools" >> "$HOME/.bashrc"
+fi
+export PATH=$PATH:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$ANDROID_SDK_ROOT/platform-tools
+
+# Accept licenses
+yes | sdkmanager --licenses
+


### PR DESCRIPTION
## Summary
- create setup.sh to install JDK 11 and Android SDK tools
- export ANDROID_SDK_ROOT and add sdkmanager to PATH
- document how to run the setup script in README

## Testing
- `gradle test --no-daemon` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_684d582021ec832c8eeb129a9ae08812