### PR TITLE
Implement Route export to GPX and KML

### DIFF
--- a/core/src/main/java/com/correos/delivery/export/KmlExporter.java
+++ b/core/src/main/java/com/correos/delivery/export/KmlExporter.java
@@ -1,0 +1,41 @@
+package com.correos.delivery.export;
+
+import com.example.routes.Address;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Utility class that exports a list of {@link Address} instances to a simple
+ * KML file so it can be loaded by navigation apps supporting this format.
+ */
+public class KmlExporter {
+
+    /**
+     * Write the provided route to a KML file.
+     *
+     * @param route ordered list of addresses representing the route
+     * @return file pointing to the generated KML document
+     * @throws IOException if the file cannot be written
+     */
+    public File export(List<Address> route) throws IOException {
+        File file = File.createTempFile("route", ".kml");
+        try (FileWriter writer = new FileWriter(file)) {
+            writer.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+            writer.write("<kml xmlns=\"http://www.opengis.net/kml/2.2\">\n");
+            writer.write("  <Document>\n");
+            writer.write("    <name>Route</name>\n");
+            for (Address a : route) {
+                writer.write(String.format(
+                        "    <Placemark><name>%s %s %s</name><Point><coordinates>%f,%f</coordinates></Point></Placemark>\n",
+                        a.getPostalCode(), a.getStreet(), a.getNumber(),
+                        a.getLongitude(), a.getLatitude()));
+            }
+            writer.write("  </Document>\n");
+            writer.write("</kml>\n");
+        }
+        return file;
+    }
+}

--- a/core/src/main/java/com/example/routes/Route.kt
+++ b/core/src/main/java/com/example/routes/Route.kt
@@ -1,8 +1,39 @@
 package com.example.routes
 
-// TODO: define route fields
-class Route(
-    val addresses: List<Address>
+import com.correos.delivery.export.GpxExporter
+import com.correos.delivery.export.KmlExporter
+import java.io.File
+import java.io.IOException
+
+/**
+ * Represents a route consisting of an origin, destination and optional
+ * intermediate waypoints.
+ */
+data class Route(
+    val origin: Address,
+    val destination: Address,
+    val waypoints: List<Address> = emptyList()
 ) {
-    // TODO: add functions to convert to GPX/KML
+
+    /**
+     * Convenience method returning all stops in order starting from the origin
+     * and ending at the destination.
+     */
+    fun allStops(): List<Address> = listOf(origin) + waypoints + destination
+
+    /**
+     * Export this route to a GPX file using [GpxExporter].
+     *
+     * @throws IOException if the file cannot be written
+     */
+    @Throws(IOException::class)
+    fun toGpx(): File = GpxExporter().export(allStops())
+
+    /**
+     * Export this route to a KML file using [KmlExporter].
+     *
+     * @throws IOException if the file cannot be written
+     */
+    @Throws(IOException::class)
+    fun toKml(): File = KmlExporter().export(allStops())
 }

--- a/core/src/test/java/com/example/routes/RouteExportTest.kt
+++ b/core/src/test/java/com/example/routes/RouteExportTest.kt
@@ -1,0 +1,31 @@
+package com.example.routes
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RouteExportTest {
+    private val origin = Address("0", "Origin", "1", 0.0, 0.0)
+    private val waypoint = Address("1", "Waypoint", "1", 0.5, 0.5)
+    private val destination = Address("2", "Dest", "2", 1.0, 1.0)
+    private val route = Route(origin, destination, listOf(waypoint))
+
+    @Test
+    fun toGpxCreatesGpxFile() {
+        val file = route.toGpx()
+        val text = file.readText()
+        assertTrue(text.contains("<gpx"))
+        assertTrue(text.contains("lat=\"0.0\" lon=\"0.0\""))
+        assertTrue(text.contains("lat=\"0.5\" lon=\"0.5\""))
+        assertTrue(text.contains("lat=\"1.0\" lon=\"1.0\""))
+    }
+
+    @Test
+    fun toKmlCreatesKmlFile() {
+        val file = route.toKml()
+        val text = file.readText()
+        assertTrue(text.contains("<kml"))
+        assertTrue(text.contains(",0.0</coordinates>"))
+        assertTrue(text.contains(",0.5</coordinates>"))
+        assertTrue(text.contains(",1.0</coordinates>"))
+    }
+}


### PR DESCRIPTION
## Summary
- expand `Route` data model with origin/destination and waypoint list
- add ability to export a route to GPX or KML
- introduce `KmlExporter` for writing KML files
- provide tests for the new export functions

## Testing
- `gradle :core:test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_684d799f4d10832c8bb857911db953a4