### PR TITLE
Add speech recognizer cleanup

### DIFF
--- a/app/src/main/java/com/example/routes/MainActivity.kt
+++ b/app/src/main/java/com/example/routes/MainActivity.kt
@@ -158,4 +158,9 @@ class MainActivity : AppCompatActivity(), SpeechRecognitionService.Callback {
             Toast.makeText(this, "No app found to open GPX", Toast.LENGTH_SHORT).show()
         }
     }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        speechService.release()
+    }
 }

--- a/core/src/main/java/com/correos/delivery/core/SpeechRecognitionService.java
+++ b/core/src/main/java/com/correos/delivery/core/SpeechRecognitionService.java
@@ -35,6 +35,14 @@ public class SpeechRecognitionService {
                 RecognizerIntent.LANGUAGE_MODEL_FREE_FORM);
     }
 
+    /** Visible for testing */
+    SpeechRecognitionService(SpeechRecognizer recognizer, Intent intent, Callback callback) {
+        this.callback = callback;
+        this.recognizer = recognizer;
+        this.recognizer.setRecognitionListener(new Listener());
+        this.recognizerIntent = intent;
+    }
+
     /** Start listening for speech input. */
     public void startListening() {
         recognizer.startListening(recognizerIntent);
@@ -43,6 +51,14 @@ public class SpeechRecognitionService {
     /** Stop listening for speech input. */
     public void stopListening() {
         recognizer.stopListening();
+    }
+
+    /**
+     * Release the underlying {@link SpeechRecognizer} and associated resources.
+     * This should be called when the service is no longer needed.
+     */
+    public void release() {
+        recognizer.destroy();
     }
 
     private class Listener implements RecognitionListener {

--- a/core/src/test/java/com/correos/delivery/core/SpeechRecognitionServiceTest.kt
+++ b/core/src/test/java/com/correos/delivery/core/SpeechRecognitionServiceTest.kt
@@ -1,0 +1,23 @@
+package com.correos.delivery.core
+
+import android.content.Intent
+import android.speech.SpeechRecognizer
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+
+class SpeechRecognitionServiceTest {
+
+    @Test
+    fun releaseDestroysRecognizer() {
+        val recognizer = mock(SpeechRecognizer::class.java)
+        val intent = Intent()
+        val service = SpeechRecognitionService(recognizer, intent, object : SpeechRecognitionService.Callback {
+            override fun onSpeechResults(results: List<String>) {}
+        })
+
+        service.release()
+
+        verify(recognizer).destroy()
+    }
+}


### PR DESCRIPTION
## Summary
- add a testing constructor and `release()` to `SpeechRecognitionService`
- dispose speech recognition in `MainActivity.onDestroy`
- test that `destroy()` is called

## Testing
- `gradle test --no-daemon` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_684d7bb9fe88832c902604ee8c32eb72