### PR TITLE
Add Kotlin Gradle plugin dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.21"
     }
 }
 


### PR DESCRIPTION
## Summary
- enable Kotlin build support by adding `kotlin-gradle-plugin` to root `build.gradle`

## Testing
- `./gradlew help` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684d8247dc34832c92f56effdbe191ca