### PR TITLE
Add external API dependencies

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -6,7 +6,10 @@ dependencies {
     // HTTP client for calling Google Maps APIs
     implementation 'com.squareup.okhttp3:okhttp:4.11.0'
     implementation 'org.json:json:20231018'
-    // TODO: add OpenAI and Google Maps dependencies
+    // Google Maps Java client
+    implementation 'com.google.maps:google-maps-services:2.2.0'
+    // OpenAI API client
+    implementation 'com.theokanning.openai-gpt3-java:client:0.12.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:5.5.0'
 }


### PR DESCRIPTION
## Summary
- add required OpenAI and Google Maps dependencies in `api/build.gradle`

## Testing
- `./gradlew test --no-daemon` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684d830a156c832cafc3b0f35069d0b1