### PR TITLE
Improve docs and API key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,13 @@ El JAR del wrapper se almacena en formato base64 para evitar subir archivos bina
 ```bash
 ./gradlew assemble
 ```
+
+El script `setup.sh` ahora también instala `platform-tools`, `platforms;android-33` y `build-tools;33.0.0` para que el proyecto pueda compilarse sin pasos manuales.
+
+Para ejecutar las pruebas unitarias:
+
+```bash
+./gradlew test
+```
+
+La clave de la Google Maps Route Optimization API debe proporcionarse en la variable de entorno `GOOGLE_MAPS_API_KEY` (o en la propiedad del sistema `google.maps.apiKey`) antes de ejecutar la aplicación.

--- a/api/src/main/java/com/correos/delivery/api/RouteOptimizer.java
+++ b/api/src/main/java/com/correos/delivery/api/RouteOptimizer.java
@@ -28,6 +28,11 @@ public class RouteOptimizer {
     private static final String ENDPOINT = "https://routes.googleapis.com/directions/v2:computeRoutes";
     private static final Logger LOGGER = Logger.getLogger(RouteOptimizer.class.getName());
 
+    /** Check whether an API key was provided through configuration. */
+    private static boolean hasApiKey() {
+        return API_KEY != null && !API_KEY.isEmpty();
+    }
+
     private final OkHttpClient client;
 
     public RouteOptimizer() {
@@ -59,6 +64,10 @@ public class RouteOptimizer {
      * input list if an error occurs
      */
     public List<Address> optimize(List<Address> stops) {
+        if (!hasApiKey()) {
+            LOGGER.warning("Google Maps API key not configured");
+            return stops;
+        }
         RequestBody body = RequestBody.create(buildRequestBody(stops), MediaType.parse("application/json"));
         Request request = new Request.Builder()
                 .url(ENDPOINT + "?key=" + API_KEY)

--- a/setup.sh
+++ b/setup.sh
@@ -25,6 +25,7 @@ if ! grep -q ANDROID_SDK_ROOT "$HOME/.bashrc"; then
 fi
 export PATH=$PATH:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$ANDROID_SDK_ROOT/platform-tools
 
-# Accept licenses
+# Accept licenses and install required SDK packages
 yes | sdkmanager --licenses
+sdkmanager --install "platform-tools" "platforms;android-33" "build-tools;33.0.0"
 


### PR DESCRIPTION
## Summary
- expand Android SDK setup to install build tools and platforms
- document API key configuration and tests
- warn when Google Maps API key is missing

## Testing
- `./gradlew test --console=plain` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684d86c188f0832c98dbba2b68cf50de